### PR TITLE
Add numbering to story flow nodes

### DIFF
--- a/aige-backend/manage.py
+++ b/aige-backend/manage.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""Django's command-line utility for administrative tasks."""
+import os
+import sys
+
+
+def main():
+    """Run administrative tasks."""
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'aige.settings')
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/components/ChoicePointNode.tsx
+++ b/src/components/ChoicePointNode.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { X } from 'lucide-react';
 
 interface ChoicePointNodeData extends Record<string, unknown> {
+  nodeNumber: number;
   title: string;
   description: string;
   options: {
@@ -32,6 +33,11 @@ export const ChoicePointNode = memo(function ChoicePointNodeComponent({
 
   return (
     <Card className="w-80 bg-yellow-50 border-yellow-400 shadow-md relative">
+      {typeof data.nodeNumber === 'number' && (
+        <span className="absolute top-2 left-2 w-5 h-5 rounded-full bg-gray-200 text-gray-700 flex items-center justify-center text-xs font-semibold">
+          {data.nodeNumber}
+        </span>
+      )}
       <Handle type="target" position={Position.Top} className="w-3 h-3 !bg-yellow-400 !border-2 !border-white" />
 
       {/* Delete Button */}

--- a/src/components/StoryFlowBuilder.tsx
+++ b/src/components/StoryFlowBuilder.tsx
@@ -23,6 +23,7 @@ import { GeneratedAsset } from './WorkspaceModal';
 import { useToast } from '@/hooks/use-toast';
 
 interface StoryNodeData {
+  nodeNumber: number;
   title: string;
   description: string;
   nodeType: 'Scene' | 'Option Point' | 'Game' | 'AR Filter' | string;
@@ -47,6 +48,7 @@ interface StoryNodeData {
 }
 
 interface ChoicePointNodeData {
+  nodeNumber: number;
   title: string;
   description: string;
   options: {
@@ -73,6 +75,7 @@ const initialNodes: Node[] = [
     type: 'storyNode',
     position: { x: 250, y: 50 },
     data: {
+      nodeNumber: 1,
       title: 'Opening Scene',
       description: 'User enters the virtual showroom',
       nodeType: 'Scene',
@@ -234,6 +237,7 @@ export function StoryFlowBuilder({ onBack, onNext }: StoryFlowBuilderProps) {
         type: 'choice',
         position: { x: 100 + Math.random() * 300, y: 100 + Math.random() * 300 },
         data: {
+          nodeNumber: nodeIdCounter,
           title: 'New Choice Point',
           description: 'What happens next?',
           options: [
@@ -251,6 +255,7 @@ export function StoryFlowBuilder({ onBack, onNext }: StoryFlowBuilderProps) {
         type: 'storyNode',
         position: { x: 100 + Math.random() * 300, y: 100 + Math.random() * 300 },
         data: {
+          nodeNumber: nodeIdCounter,
           title: `New ${nodeType}`,
           description: `Description for ${nodeType.toLowerCase()}`,
           nodeType,

--- a/src/components/StoryNode.tsx
+++ b/src/components/StoryNode.tsx
@@ -16,6 +16,7 @@ interface MediaOption {
 }
 
 interface StoryNodeData {
+  nodeNumber: number;
   title: string;
   description: string;
   nodeType: 'Scene' | 'Option Point' | 'Game' | 'AR Filter' | string;
@@ -128,6 +129,11 @@ export const StoryNode = memo(function StoryNodeComponent({
   return (
     <>
       <Card className={`w-80 ${getNodeColor(data.nodeType)} shadow-md relative`}>
+        {typeof data.nodeNumber === 'number' && (
+          <span className="absolute top-2 left-2 w-5 h-5 rounded-full bg-gray-200 text-gray-700 flex items-center justify-center text-xs font-semibold">
+            {data.nodeNumber}
+          </span>
+        )}
         <Handle type="target" position={Position.Top} className="w-3 h-3 !bg-yellow-400 !border-2 !border-white" />
 
         {/* Delete Button */}


### PR DESCRIPTION
## Summary
- extend node data with `nodeNumber`
- show `nodeNumber` badges on StoryNode and ChoicePointNode
- assign sequential numbers when creating nodes

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6853e7981f28832983bdf5f001a5983b